### PR TITLE
fix(ui): apply vertical offset to triangle polygons for visual alignment

### DIFF
--- a/app/src/androidTest/java/fr/mandarine/diceroller/TriangleDiceAlignmentUiTest.kt
+++ b/app/src/androidTest/java/fr/mandarine/diceroller/TriangleDiceAlignmentUiTest.kt
@@ -1,0 +1,316 @@
+// app/src/androidTest/java/fr/mandarine/diceroller/TriangleDiceAlignmentUiTest.kt
+package fr.mandarine.diceroller
+
+import androidx.compose.material3.Text
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import fr.mandarine.diceroller.domain.Dice
+import fr.mandarine.diceroller.presentation.component.DicePolygon
+import fr.mandarine.diceroller.presentation.component.DicePolygonSize
+import fr.mandarine.diceroller.ui.theme.DiceRollerTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Compose UI tests for the triangle dice alignment fix.
+ *
+ * Verifies that [DicePolygon] renders without layout errors for D4 and D20
+ * (triangle polygons with a non-zero [fr.mandarine.diceroller.presentation.model.DiceShape.verticalOffsetFraction])
+ * at both [DicePolygonSize.Small] and [DicePolygonSize.Large] size variants,
+ * and that non-triangle dice (D6, D8, D12) are equally unaffected.
+ *
+ * Each test uses a known text label as the `content` slot so that
+ * [assertIsDisplayed] can confirm the composable composed and laid out
+ * successfully without throwing an exception.
+ */
+@RunWith(AndroidJUnit4::class)
+class TriangleDiceAlignmentUiTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    // -------------------------------------------------------------------------
+    // D4 (Triangle) — both size variants
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun givenD4_whenRenderedAtSmallSize_thenContentLabelIsDisplayed() {
+        composeTestRule.setContent {
+            DiceRollerTheme(dynamicColor = false) {
+                DicePolygon(dice = Dice.D4, sizeVariant = DicePolygonSize.Small) {
+                    Text(text = "D4")
+                }
+            }
+        }
+
+        composeTestRule.onNodeWithText("D4").assertIsDisplayed()
+    }
+
+    @Test
+    fun givenD4_whenRenderedAtLargeSize_thenContentLabelIsDisplayed() {
+        composeTestRule.setContent {
+            DiceRollerTheme(dynamicColor = false) {
+                DicePolygon(dice = Dice.D4, sizeVariant = DicePolygonSize.Large) {
+                    Text(text = "D4")
+                }
+            }
+        }
+
+        composeTestRule.onNodeWithText("D4").assertIsDisplayed()
+    }
+
+    // -------------------------------------------------------------------------
+    // D20 (Icosahedron / Triangle) — both size variants
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun givenD20_whenRenderedAtSmallSize_thenContentLabelIsDisplayed() {
+        composeTestRule.setContent {
+            DiceRollerTheme(dynamicColor = false) {
+                DicePolygon(dice = Dice.D20, sizeVariant = DicePolygonSize.Small) {
+                    Text(text = "D20")
+                }
+            }
+        }
+
+        composeTestRule.onNodeWithText("D20").assertIsDisplayed()
+    }
+
+    @Test
+    fun givenD20_whenRenderedAtLargeSize_thenContentLabelIsDisplayed() {
+        composeTestRule.setContent {
+            DiceRollerTheme(dynamicColor = false) {
+                DicePolygon(dice = Dice.D20, sizeVariant = DicePolygonSize.Large) {
+                    Text(text = "D20")
+                }
+            }
+        }
+
+        composeTestRule.onNodeWithText("D20").assertIsDisplayed()
+    }
+
+    // -------------------------------------------------------------------------
+    // D4 / D20 — selected state (fills polygon background)
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun givenD4Selected_whenRenderedAtSmallSize_thenContentLabelIsDisplayed() {
+        composeTestRule.setContent {
+            DiceRollerTheme(dynamicColor = false) {
+                DicePolygon(dice = Dice.D4, sizeVariant = DicePolygonSize.Small, isSelected = true) {
+                    Text(text = "D4")
+                }
+            }
+        }
+
+        composeTestRule.onNodeWithText("D4").assertIsDisplayed()
+    }
+
+    @Test
+    fun givenD20Selected_whenRenderedAtSmallSize_thenContentLabelIsDisplayed() {
+        composeTestRule.setContent {
+            DiceRollerTheme(dynamicColor = false) {
+                DicePolygon(dice = Dice.D20, sizeVariant = DicePolygonSize.Small, isSelected = true) {
+                    Text(text = "D20")
+                }
+            }
+        }
+
+        composeTestRule.onNodeWithText("D20").assertIsDisplayed()
+    }
+
+    // -------------------------------------------------------------------------
+    // D4 / D20 — dark theme
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun givenD4DarkTheme_whenRenderedAtLargeSize_thenContentLabelIsDisplayed() {
+        composeTestRule.setContent {
+            DiceRollerTheme(darkTheme = true, dynamicColor = false) {
+                DicePolygon(dice = Dice.D4, sizeVariant = DicePolygonSize.Large) {
+                    Text(text = "D4")
+                }
+            }
+        }
+
+        composeTestRule.onNodeWithText("D4").assertIsDisplayed()
+    }
+
+    @Test
+    fun givenD20DarkTheme_whenRenderedAtLargeSize_thenContentLabelIsDisplayed() {
+        composeTestRule.setContent {
+            DiceRollerTheme(darkTheme = true, dynamicColor = false) {
+                DicePolygon(dice = Dice.D20, sizeVariant = DicePolygonSize.Large) {
+                    Text(text = "D20")
+                }
+            }
+        }
+
+        composeTestRule.onNodeWithText("D20").assertIsDisplayed()
+    }
+
+    // -------------------------------------------------------------------------
+    // Non-triangle polygons are unaffected — D6, D8, D12
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun givenD6_whenRenderedAtSmallSize_thenContentLabelIsDisplayed() {
+        composeTestRule.setContent {
+            DiceRollerTheme(dynamicColor = false) {
+                DicePolygon(dice = Dice.D6, sizeVariant = DicePolygonSize.Small) {
+                    Text(text = "D6")
+                }
+            }
+        }
+
+        composeTestRule.onNodeWithText("D6").assertIsDisplayed()
+    }
+
+    @Test
+    fun givenD6_whenRenderedAtLargeSize_thenContentLabelIsDisplayed() {
+        composeTestRule.setContent {
+            DiceRollerTheme(dynamicColor = false) {
+                DicePolygon(dice = Dice.D6, sizeVariant = DicePolygonSize.Large) {
+                    Text(text = "D6")
+                }
+            }
+        }
+
+        composeTestRule.onNodeWithText("D6").assertIsDisplayed()
+    }
+
+    @Test
+    fun givenD8_whenRenderedAtSmallSize_thenContentLabelIsDisplayed() {
+        composeTestRule.setContent {
+            DiceRollerTheme(dynamicColor = false) {
+                DicePolygon(dice = Dice.D8, sizeVariant = DicePolygonSize.Small) {
+                    Text(text = "D8")
+                }
+            }
+        }
+
+        composeTestRule.onNodeWithText("D8").assertIsDisplayed()
+    }
+
+    @Test
+    fun givenD8_whenRenderedAtLargeSize_thenContentLabelIsDisplayed() {
+        composeTestRule.setContent {
+            DiceRollerTheme(dynamicColor = false) {
+                DicePolygon(dice = Dice.D8, sizeVariant = DicePolygonSize.Large) {
+                    Text(text = "D8")
+                }
+            }
+        }
+
+        composeTestRule.onNodeWithText("D8").assertIsDisplayed()
+    }
+
+    @Test
+    fun givenD12_whenRenderedAtSmallSize_thenContentLabelIsDisplayed() {
+        composeTestRule.setContent {
+            DiceRollerTheme(dynamicColor = false) {
+                DicePolygon(dice = Dice.D12, sizeVariant = DicePolygonSize.Small) {
+                    Text(text = "D12")
+                }
+            }
+        }
+
+        composeTestRule.onNodeWithText("D12").assertIsDisplayed()
+    }
+
+    @Test
+    fun givenD12_whenRenderedAtLargeSize_thenContentLabelIsDisplayed() {
+        composeTestRule.setContent {
+            DiceRollerTheme(dynamicColor = false) {
+                DicePolygon(dice = Dice.D12, sizeVariant = DicePolygonSize.Large) {
+                    Text(text = "D12")
+                }
+            }
+        }
+
+        composeTestRule.onNodeWithText("D12").assertIsDisplayed()
+    }
+
+    // -------------------------------------------------------------------------
+    // Full screen smoke test — D4 and D20 in the selector row render correctly
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun givenScreenWithD4AsSelectedDice_whenScreenIsDisplayed_thenD4SelectorIsPresent() {
+        composeTestRule.setContent {
+            DiceRollerTheme(dynamicColor = false) {
+                DiceRollerScreen(
+                    uiState = fr.mandarine.diceroller.presentation.DiceRollerUiState(
+                        selectedDice = Dice.D4,
+                        result = null,
+                    ),
+                    onSelectDice = {},
+                    onRollDice = {},
+                )
+            }
+        }
+
+        composeTestRule
+            .onNodeWithText("Roll D4")
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun givenScreenWithD20AsSelectedDice_whenScreenIsDisplayed_thenD20SelectorIsPresent() {
+        composeTestRule.setContent {
+            DiceRollerTheme(dynamicColor = false) {
+                DiceRollerScreen(
+                    uiState = fr.mandarine.diceroller.presentation.DiceRollerUiState(
+                        selectedDice = Dice.D20,
+                        result = null,
+                    ),
+                    onSelectDice = {},
+                    onRollDice = {},
+                )
+            }
+        }
+
+        composeTestRule
+            .onNodeWithText("Roll D20")
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun givenScreenWithD4ResultDisplayed_whenScreenIsRendered_thenResultValueIsShown() {
+        composeTestRule.setContent {
+            DiceRollerTheme(dynamicColor = false) {
+                DiceRollerScreen(
+                    uiState = fr.mandarine.diceroller.presentation.DiceRollerUiState(
+                        selectedDice = Dice.D4,
+                        result = 3,
+                    ),
+                    onSelectDice = {},
+                    onRollDice = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("3").assertIsDisplayed()
+    }
+
+    @Test
+    fun givenScreenWithD20ResultDisplayed_whenScreenIsRendered_thenResultValueIsShown() {
+        composeTestRule.setContent {
+            DiceRollerTheme(dynamicColor = false) {
+                DiceRollerScreen(
+                    uiState = fr.mandarine.diceroller.presentation.DiceRollerUiState(
+                        selectedDice = Dice.D20,
+                        result = 17,
+                    ),
+                    onSelectDice = {},
+                    onRollDice = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("17").assertIsDisplayed()
+    }
+}

--- a/app/src/main/java/fr/mandarine/diceroller/presentation/component/DicePolygon.kt
+++ b/app/src/main/java/fr/mandarine/diceroller/presentation/component/DicePolygon.kt
@@ -63,6 +63,7 @@ fun DicePolygon(
             val path = buildPolygonPath(
                 vertexCount = shape.vertexCount,
                 rotationDegrees = shape.rotationDegrees,
+                verticalOffsetFraction = shape.verticalOffsetFraction,
             )
             drawPath(path = path, color = fillColor)
             drawPath(path = path, color = strokeColor, style = Stroke(width = strokeWidthPx))
@@ -80,15 +81,20 @@ fun DicePolygon(
  *
  * @param vertexCount number of vertices (e.g. 3 for triangle, 4 for square)
  * @param rotationDegrees initial rotation offset in degrees
+ * @param verticalOffsetFraction fraction of the polygon radius added to the
+ *        center Y coordinate. Negative values shift the polygon upward,
+ *        correcting optical misalignment for triangle shapes.
  */
 private fun DrawScope.buildPolygonPath(
     vertexCount: Int,
     rotationDegrees: Float,
+    verticalOffsetFraction: Float = 0f,
 ): Path {
     val cx = size.width / 2f
     val cy = size.height / 2f
     val strokeInset = 4f // pixels to keep the stroke fully inside the canvas
     val radius = min(cx, cy) - strokeInset
+    val offsetCy = cy + verticalOffsetFraction * radius
     val angleStep = 2.0 * PI / vertexCount
     val startAngle = rotationDegrees * PI / 180.0
 
@@ -96,7 +102,7 @@ private fun DrawScope.buildPolygonPath(
         for (i in 0 until vertexCount) {
             val angle = startAngle + i * angleStep
             val x = cx + (radius * cos(angle)).toFloat()
-            val y = cy + (radius * sin(angle)).toFloat()
+            val y = offsetCy + (radius * sin(angle)).toFloat()
             if (i == 0) moveTo(x, y) else lineTo(x, y)
         }
         close()

--- a/app/src/main/java/fr/mandarine/diceroller/presentation/model/DiceShape.kt
+++ b/app/src/main/java/fr/mandarine/diceroller/presentation/model/DiceShape.kt
@@ -15,14 +15,22 @@ import fr.mandarine.diceroller.domain.Dice
  * @property vertexCount number of vertices in the regular polygon
  * @property rotationDegrees clockwise rotation in degrees applied before drawing,
  *           used to orient the polygon (e.g. point-up for triangles)
+ * @property verticalOffsetFraction fraction of the polygon radius applied as a
+ *           vertical translation to correct optical misalignment. Negative values
+ *           shift the polygon upward. Non-triangle shapes use `0f`.
  */
 sealed class DiceShape(
     val vertexCount: Int,
     val rotationDegrees: Float,
+    val verticalOffsetFraction: Float = 0f,
 ) {
 
     /** D4 -- equilateral triangle, point-up orientation. */
-    data object Triangle : DiceShape(vertexCount = 3, rotationDegrees = -90f)
+    data object Triangle : DiceShape(
+        vertexCount = 3,
+        rotationDegrees = -90f,
+        verticalOffsetFraction = TRIANGLE_VERTICAL_OFFSET,
+    )
 
     /** D6 -- square rotated 45 degrees so sides are horizontal/vertical. */
     data object Square : DiceShape(vertexCount = 4, rotationDegrees = 45f)
@@ -34,9 +42,23 @@ sealed class DiceShape(
     data object Pentagon : DiceShape(vertexCount = 5, rotationDegrees = -90f)
 
     /** D20 -- rendered as a triangle (like D4); may gain corner-clipping later. */
-    data object Icosahedron : DiceShape(vertexCount = 3, rotationDegrees = -90f)
+    data object Icosahedron : DiceShape(
+        vertexCount = 3,
+        rotationDegrees = -90f,
+        verticalOffsetFraction = TRIANGLE_VERTICAL_OFFSET,
+    )
 
     companion object {
+        /**
+         * Vertical offset fraction for triangle polygons.
+         *
+         * Equilateral triangles appear optically top-heavy when centered
+         * by their circumscribed circle. Shifting the polygon upward by
+         * one-sixth of the radius corrects the visual imbalance so
+         * triangles align with other shapes in a row.
+         */
+        private const val TRIANGLE_VERTICAL_OFFSET = -1f / 6f
+
         /**
          * Returns the [DiceShape] corresponding to the given [dice] value.
          *

--- a/app/src/test/java/fr/mandarine/diceroller/presentation/model/DiceShapeTest.kt
+++ b/app/src/test/java/fr/mandarine/diceroller/presentation/model/DiceShapeTest.kt
@@ -1,0 +1,276 @@
+// app/src/test/java/fr/mandarine/diceroller/presentation/model/DiceShapeTest.kt
+package fr.mandarine.diceroller.presentation.model
+
+import fr.mandarine.diceroller.domain.Dice
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for [DiceShape].
+ *
+ * Verifies:
+ * - Triangle polygons (D4 / D20) receive a non-zero negative [DiceShape.verticalOffsetFraction]
+ * - Non-triangle polygons (D6, D8, D12) receive a zero [DiceShape.verticalOffsetFraction]
+ * - [DiceShape.fromDice] maps every [Dice] value to the expected subtype
+ * - Structural properties (vertexCount, rotationDegrees) match the spec
+ */
+class DiceShapeTest {
+
+    // -------------------------------------------------------------------------
+    // vertexCount
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun givenTriangle_whenReadingVertexCount_thenItIsThree() {
+        val shape = DiceShape.Triangle
+
+        assertEquals(3, shape.vertexCount)
+    }
+
+    @Test
+    fun givenIcosahedron_whenReadingVertexCount_thenItIsThree() {
+        val shape = DiceShape.Icosahedron
+
+        assertEquals(3, shape.vertexCount)
+    }
+
+    @Test
+    fun givenSquare_whenReadingVertexCount_thenItIsFour() {
+        val shape = DiceShape.Square
+
+        assertEquals(4, shape.vertexCount)
+    }
+
+    @Test
+    fun givenOctagon_whenReadingVertexCount_thenItIsEight() {
+        val shape = DiceShape.Octagon
+
+        assertEquals(8, shape.vertexCount)
+    }
+
+    @Test
+    fun givenPentagon_whenReadingVertexCount_thenItIsFive() {
+        val shape = DiceShape.Pentagon
+
+        assertEquals(5, shape.vertexCount)
+    }
+
+    // -------------------------------------------------------------------------
+    // verticalOffsetFraction — triangle polygons must have a non-zero offset
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun givenTriangle_whenReadingVerticalOffsetFraction_thenItIsNonZero() {
+        val shape = DiceShape.Triangle
+
+        assertTrue(
+            "Expected non-zero verticalOffsetFraction for Triangle, got ${shape.verticalOffsetFraction}",
+            shape.verticalOffsetFraction != 0f,
+        )
+    }
+
+    @Test
+    fun givenTriangle_whenReadingVerticalOffsetFraction_thenItIsNegative() {
+        val shape = DiceShape.Triangle
+
+        assertTrue(
+            "Expected negative verticalOffsetFraction for Triangle (upward shift), got ${shape.verticalOffsetFraction}",
+            shape.verticalOffsetFraction < 0f,
+        )
+    }
+
+    @Test
+    fun givenIcosahedron_whenReadingVerticalOffsetFraction_thenItIsNonZero() {
+        val shape = DiceShape.Icosahedron
+
+        assertTrue(
+            "Expected non-zero verticalOffsetFraction for Icosahedron, got ${shape.verticalOffsetFraction}",
+            shape.verticalOffsetFraction != 0f,
+        )
+    }
+
+    @Test
+    fun givenIcosahedron_whenReadingVerticalOffsetFraction_thenItIsNegative() {
+        val shape = DiceShape.Icosahedron
+
+        assertTrue(
+            "Expected negative verticalOffsetFraction for Icosahedron (upward shift), got ${shape.verticalOffsetFraction}",
+            shape.verticalOffsetFraction < 0f,
+        )
+    }
+
+    @Test
+    fun givenTriangleAndIcosahedron_whenComparingVerticalOffsetFractions_thenTheyAreEqual() {
+        val triangleOffset = DiceShape.Triangle.verticalOffsetFraction
+        val icosahedronOffset = DiceShape.Icosahedron.verticalOffsetFraction
+
+        assertEquals(
+            "D4 (Triangle) and D20 (Icosahedron) must share the same vertical offset constant",
+            triangleOffset,
+            icosahedronOffset,
+            0.0001f,
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // verticalOffsetFraction — non-triangle polygons must have zero offset
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun givenSquare_whenReadingVerticalOffsetFraction_thenItIsZero() {
+        val shape = DiceShape.Square
+
+        assertEquals(0f, shape.verticalOffsetFraction, 0f)
+    }
+
+    @Test
+    fun givenOctagon_whenReadingVerticalOffsetFraction_thenItIsZero() {
+        val shape = DiceShape.Octagon
+
+        assertEquals(0f, shape.verticalOffsetFraction, 0f)
+    }
+
+    @Test
+    fun givenPentagon_whenReadingVerticalOffsetFraction_thenItIsZero() {
+        val shape = DiceShape.Pentagon
+
+        assertEquals(0f, shape.verticalOffsetFraction, 0f)
+    }
+
+    // -------------------------------------------------------------------------
+    // fromDice — correct subtype mapping
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun givenD4_whenCallingFromDice_thenReturnsTriangle() {
+        val shape = DiceShape.fromDice(Dice.D4)
+
+        assertTrue("Expected Triangle for D4, got $shape", shape is DiceShape.Triangle)
+    }
+
+    @Test
+    fun givenD6_whenCallingFromDice_thenReturnsSquare() {
+        val shape = DiceShape.fromDice(Dice.D6)
+
+        assertTrue("Expected Square for D6, got $shape", shape is DiceShape.Square)
+    }
+
+    @Test
+    fun givenD8_whenCallingFromDice_thenReturnsOctagon() {
+        val shape = DiceShape.fromDice(Dice.D8)
+
+        assertTrue("Expected Octagon for D8, got $shape", shape is DiceShape.Octagon)
+    }
+
+    @Test
+    fun givenD12_whenCallingFromDice_thenReturnsPentagon() {
+        val shape = DiceShape.fromDice(Dice.D12)
+
+        assertTrue("Expected Pentagon for D12, got $shape", shape is DiceShape.Pentagon)
+    }
+
+    @Test
+    fun givenD20_whenCallingFromDice_thenReturnsIcosahedron() {
+        val shape = DiceShape.fromDice(Dice.D20)
+
+        assertTrue("Expected Icosahedron for D20, got $shape", shape is DiceShape.Icosahedron)
+    }
+
+    // -------------------------------------------------------------------------
+    // fromDice — verticalOffsetFraction propagation
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun givenD4_whenCallingFromDice_thenVerticalOffsetFractionIsNonZero() {
+        val shape = DiceShape.fromDice(Dice.D4)
+
+        assertTrue(
+            "Expected non-zero verticalOffsetFraction for D4, got ${shape.verticalOffsetFraction}",
+            shape.verticalOffsetFraction != 0f,
+        )
+    }
+
+    @Test
+    fun givenD20_whenCallingFromDice_thenVerticalOffsetFractionIsNonZero() {
+        val shape = DiceShape.fromDice(Dice.D20)
+
+        assertTrue(
+            "Expected non-zero verticalOffsetFraction for D20, got ${shape.verticalOffsetFraction}",
+            shape.verticalOffsetFraction != 0f,
+        )
+    }
+
+    @Test
+    fun givenD6_whenCallingFromDice_thenVerticalOffsetFractionIsZero() {
+        val shape = DiceShape.fromDice(Dice.D6)
+
+        assertEquals(
+            "D6 (Square) must have zero verticalOffsetFraction",
+            0f,
+            shape.verticalOffsetFraction,
+            0f,
+        )
+    }
+
+    @Test
+    fun givenD8_whenCallingFromDice_thenVerticalOffsetFractionIsZero() {
+        val shape = DiceShape.fromDice(Dice.D8)
+
+        assertEquals(
+            "D8 (Octagon) must have zero verticalOffsetFraction",
+            0f,
+            shape.verticalOffsetFraction,
+            0f,
+        )
+    }
+
+    @Test
+    fun givenD12_whenCallingFromDice_thenVerticalOffsetFractionIsZero() {
+        val shape = DiceShape.fromDice(Dice.D12)
+
+        assertEquals(
+            "D12 (Pentagon) must have zero verticalOffsetFraction",
+            0f,
+            shape.verticalOffsetFraction,
+            0f,
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // fromDice — all triangle dice share the same negative offset value
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun givenD4AndD20_whenCallingFromDice_thenBothHaveIdenticalVerticalOffsetFraction() {
+        val d4Shape = DiceShape.fromDice(Dice.D4)
+        val d20Shape = DiceShape.fromDice(Dice.D20)
+
+        assertEquals(
+            "D4 and D20 must share the same verticalOffsetFraction constant",
+            d4Shape.verticalOffsetFraction,
+            d20Shape.verticalOffsetFraction,
+            0.0001f,
+        )
+    }
+
+    @Test
+    fun givenD4_whenCallingFromDice_thenVerticalOffsetFractionIsNegative() {
+        val shape = DiceShape.fromDice(Dice.D4)
+
+        assertTrue(
+            "Expected negative verticalOffsetFraction for D4, got ${shape.verticalOffsetFraction}",
+            shape.verticalOffsetFraction < 0f,
+        )
+    }
+
+    @Test
+    fun givenD20_whenCallingFromDice_thenVerticalOffsetFractionIsNegative() {
+        val shape = DiceShape.fromDice(Dice.D20)
+
+        assertTrue(
+            "Expected negative verticalOffsetFraction for D20, got ${shape.verticalOffsetFraction}",
+            shape.verticalOffsetFraction < 0f,
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Add `verticalOffsetFraction` property to `DiceShape` to support per-shape vertical translation
- Triangle shapes (D4/D20) use an offset of `-1/6 * radius` to shift upward and correct optical misalignment
- Update `buildPolygonPath()` in `DicePolygon.kt` to apply the offset when computing vertex positions
- Non-triangle shapes (D6, D8, D12) are unaffected (offset defaults to `0f`)

## Closes
Closes #27

## Test plan
- [ ] Build compiles without errors
- [ ] D4 and D20 appear visually centered alongside D6, D8, D12 in selector row
- [ ] D4 and D20 appear visually centered in result display area
- [ ] D6, D8, D12 rendering is unchanged
- [ ] Both Small and Large size variants render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)