### PR TITLE
feat(ui): add RPG-style Vector Drawable assets for D4, D6, D8, D12, D20

### DIFF
--- a/app/src/main/res/drawable/ic_dice_d12.xml
+++ b/app/src/main/res/drawable/ic_dice_d12.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    D12 — pentagon, point-up.
+    Outer pentagon + inner pentagon ring + five lines from inner corners to center.
+    Single-color paths; tint applied at runtime by DiceImage.
+
+    Outer pentagon vertices (point-up, center 12,12.5, radius ~10.5):
+      Top:    12.00,  2.00
+      Right:  21.97,  9.04
+      BR:     17.51, 21.50
+      BL:      6.49, 21.50
+      Left:    2.03,  9.04
+
+    Inner pentagon (center 12,12.5, radius ~5.5):
+      Top:    12.00,  7.00
+      Right:  17.23, 10.90
+      BR:     15.24, 17.00
+      BL:      8.76, 17.00
+      Left:    6.77, 10.90
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <!-- Outer pentagon -->
+    <path
+        android:pathData="M12,2 L22,9 L17.5,21.5 L6.5,21.5 L2,9 Z"
+        android:strokeColor="#FF000000"
+        android:strokeWidth="1.2"
+        android:fillColor="#00000000" />
+
+    <!-- Inner pentagon ring -->
+    <path
+        android:pathData="M12,7 L17.2,10.9 L15.2,17 L8.8,17 L6.8,10.9 Z"
+        android:strokeColor="#FF000000"
+        android:strokeWidth="0.8"
+        android:fillColor="#00000000" />
+
+    <!-- Lines from inner corners to center (12, 12.5) -->
+    <path
+        android:pathData="M12,7 L12,12.5"
+        android:strokeColor="#FF000000"
+        android:strokeWidth="0.6"
+        android:fillColor="#00000000" />
+    <path
+        android:pathData="M17.2,10.9 L12,12.5"
+        android:strokeColor="#FF000000"
+        android:strokeWidth="0.6"
+        android:fillColor="#00000000" />
+    <path
+        android:pathData="M15.2,17 L12,12.5"
+        android:strokeColor="#FF000000"
+        android:strokeWidth="0.6"
+        android:fillColor="#00000000" />
+    <path
+        android:pathData="M8.8,17 L12,12.5"
+        android:strokeColor="#FF000000"
+        android:strokeWidth="0.6"
+        android:fillColor="#00000000" />
+    <path
+        android:pathData="M6.8,10.9 L12,12.5"
+        android:strokeColor="#FF000000"
+        android:strokeWidth="0.6"
+        android:fillColor="#00000000" />
+
+</vector>

--- a/app/src/main/res/drawable/ic_dice_d20.xml
+++ b/app/src/main/res/drawable/ic_dice_d20.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    D20 — equilateral triangle with icosahedron face markings.
+    Outer triangle + horizontal midpoint line + two lines from midpoints to center.
+    This is the canonical D20 symbol: the triangular face of an icosahedron
+    with its three medial lines connecting edge midpoints.
+    Single-color paths; tint applied at runtime by DiceImage.
+
+    Outer triangle (point-up, inset 1.5dp):
+      Top:   12.0,  1.5
+      BR:    22.5, 21.5
+      BL:     1.5, 21.5
+
+    Edge midpoints:
+      Top-right:  17.25, 11.5
+      Bottom:     12.0,  21.5
+      Top-left:    6.75, 11.5
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <!-- Outer triangle -->
+    <path
+        android:pathData="M12,1.5 L22.5,21.5 L1.5,21.5 Z"
+        android:strokeColor="#FF000000"
+        android:strokeWidth="1.2"
+        android:fillColor="#00000000" />
+
+    <!-- Horizontal midpoint line (left-midpoint to right-midpoint) -->
+    <path
+        android:pathData="M6.75,11.5 L17.25,11.5"
+        android:strokeColor="#FF000000"
+        android:strokeWidth="0.9"
+        android:fillColor="#00000000" />
+
+    <!-- Left midpoint to bottom midpoint -->
+    <path
+        android:pathData="M6.75,11.5 L12,21.5"
+        android:strokeColor="#FF000000"
+        android:strokeWidth="0.9"
+        android:fillColor="#00000000" />
+
+    <!-- Right midpoint to bottom midpoint -->
+    <path
+        android:pathData="M17.25,11.5 L12,21.5"
+        android:strokeColor="#FF000000"
+        android:strokeWidth="0.9"
+        android:fillColor="#00000000" />
+
+</vector>

--- a/app/src/main/res/drawable/ic_dice_d4.xml
+++ b/app/src/main/res/drawable/ic_dice_d4.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    D4 — equilateral triangle, point-up.
+    Outer triangle + inner triangle offset from edges to suggest a raised face.
+    Single-color paths; tint is applied at runtime by DiceImage.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <!-- Outer triangle: point-up equilateral, inset 1dp from edges -->
+    <path
+        android:pathData="M12,1.5 L22.5,21.5 L1.5,21.5 Z"
+        android:strokeColor="#FF000000"
+        android:strokeWidth="1.2"
+        android:fillColor="#00000000" />
+
+    <!-- Inner triangle: suggests raised face -->
+    <path
+        android:pathData="M12,7 L18.5,19.5 L5.5,19.5 Z"
+        android:strokeColor="#FF000000"
+        android:strokeWidth="0.8"
+        android:fillColor="#00000000" />
+
+    <!-- Center base line connecting inner to outer baseline -->
+    <path
+        android:pathData="M5.5,19.5 L1.5,21.5"
+        android:strokeColor="#FF000000"
+        android:strokeWidth="0.8"
+        android:fillColor="#00000000" />
+    <path
+        android:pathData="M18.5,19.5 L22.5,21.5"
+        android:strokeColor="#FF000000"
+        android:strokeWidth="0.8"
+        android:fillColor="#00000000" />
+    <path
+        android:pathData="M12,7 L12,1.5"
+        android:strokeColor="#FF000000"
+        android:strokeWidth="0.8"
+        android:fillColor="#00000000" />
+
+</vector>

--- a/app/src/main/res/drawable/ic_dice_d6.xml
+++ b/app/src/main/res/drawable/ic_dice_d6.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    D6 — cube viewed face-on.
+    Front face (square) + top face (parallelogram) + right face (parallelogram)
+    to create a classic 3-D isometric cube silhouette.
+    Single-color paths; tint applied at runtime by DiceImage.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <!-- Front face: square -->
+    <path
+        android:pathData="M3,10 L3,22 L15,22 L15,10 Z"
+        android:strokeColor="#FF000000"
+        android:strokeWidth="1.2"
+        android:fillColor="#00000000" />
+
+    <!-- Top face: parallelogram (front-top-left to front-top-right to back-top-right to back-top-left) -->
+    <path
+        android:pathData="M3,10 L9,2 L21,2 L15,10 Z"
+        android:strokeColor="#FF000000"
+        android:strokeWidth="1.2"
+        android:fillColor="#00000000" />
+
+    <!-- Right face: parallelogram -->
+    <path
+        android:pathData="M15,10 L21,2 L21,14 L15,22 Z"
+        android:strokeColor="#FF000000"
+        android:strokeWidth="1.2"
+        android:fillColor="#00000000" />
+
+</vector>

--- a/app/src/main/res/drawable/ic_dice_d8.xml
+++ b/app/src/main/res/drawable/ic_dice_d8.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    D8 — diamond / double-pyramid silhouette (octahedron viewed from the side).
+    Outer diamond + horizontal equatorial line + two diagonal face-edge lines.
+    Single-color paths; tint applied at runtime by DiceImage.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <!-- Outer diamond -->
+    <path
+        android:pathData="M12,1.5 L22.5,12 L12,22.5 L1.5,12 Z"
+        android:strokeColor="#FF000000"
+        android:strokeWidth="1.2"
+        android:fillColor="#00000000" />
+
+    <!-- Horizontal equatorial line -->
+    <path
+        android:pathData="M1.5,12 L22.5,12"
+        android:strokeColor="#FF000000"
+        android:strokeWidth="0.8"
+        android:fillColor="#00000000" />
+
+    <!-- Left upper face-edge: top apex to left equator -->
+    <path
+        android:pathData="M12,1.5 L1.5,12"
+        android:strokeColor="#FF000000"
+        android:strokeWidth="0.5"
+        android:fillColor="#00000000" />
+
+    <!-- Right upper face-edge: top apex to right equator -->
+    <path
+        android:pathData="M12,1.5 L22.5,12"
+        android:strokeColor="#FF000000"
+        android:strokeWidth="0.5"
+        android:fillColor="#00000000" />
+
+    <!-- Center vertical spine (back edge of octahedron) -->
+    <path
+        android:pathData="M12,1.5 L12,22.5"
+        android:strokeColor="#FF000000"
+        android:strokeWidth="0.6"
+        android:fillColor="#00000000" />
+
+</vector>


### PR DESCRIPTION
## Summary
- Five Vector Drawable XML files added to `res/drawable/`: `ic_dice_d4`, `ic_dice_d6`, `ic_dice_d8`, `ic_dice_d12`, `ic_dice_d20`
- Each asset uses a single-color monochromatic path — no embedded colors or gradients — so `DiceImage` can tint them via Material 3 color scheme at runtime
- D4: equilateral triangle with inner triangle suggesting a raised face
- D6: isometric cube (front face + top face + right face parallelograms)
- D8: double-pyramid diamond with equatorial line and spine
- D12: pentagon with inner pentagon ring and five radial facet lines
- D20: equilateral triangle with medial lines (canonical icosahedron face symbol)
- Build verified: `./gradlew compileDebugKotlin` passes

## Closes
Closes #33

## Test plan
- [ ] Unit tests pass
- [ ] UI tests pass
- [ ] Manually verified on emulator