### PR TITLE
feat(ui): implement DiceAsset model and DiceImage Compose component

### DIFF
--- a/app/src/main/java/fr/mandarine/diceroller/presentation/component/DiceImage.kt
+++ b/app/src/main/java/fr/mandarine/diceroller/presentation/component/DiceImage.kt
@@ -1,0 +1,138 @@
+// app/src/main/java/fr/mandarine/diceroller/presentation/component/DiceImage.kt
+package fr.mandarine.diceroller.presentation.component
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import fr.mandarine.diceroller.R
+import fr.mandarine.diceroller.domain.Dice
+import fr.mandarine.diceroller.presentation.model.DiceAsset
+import fr.mandarine.diceroller.ui.theme.DiceRollerTheme
+
+/** Padding applied inside the bounding box so the asset stroke is never clipped. */
+private val ASSET_INNER_PADDING: Dp = 4.dp
+
+/**
+ * Size variants for [DiceImage], matching the two contexts where dice art appears.
+ *
+ * @property sizeDp the square bounding box side length
+ */
+enum class DiceImageSize(val sizeDp: Dp) {
+    /** Small variant used in the die selector chip row (48×48 dp). */
+    Small(sizeDp = 48.dp),
+
+    /** Large variant used in the roll result display (160×160 dp). */
+    Large(sizeDp = 160.dp),
+}
+
+/**
+ * Renders a static RPG-style die asset for the given [dice] type.
+ *
+ * The drawable asset is loaded via [DiceAsset.fromDice] and tinted at runtime
+ * using the provided [tintColor], so it adapts automatically to the Material 3
+ * color scheme in both light and dark mode.
+ *
+ * A [content] slot is centered inside the bounding box so callers can overlay
+ * the result number or [D6Pips] on top of the die art.
+ *
+ * @param dice the die type whose asset to render
+ * @param sizeVariant controls the physical dimensions of the component
+ * @param modifier optional [Modifier] applied to the root container
+ * @param tintColor the color used to tint the single-color drawable asset;
+ *   defaults to [MaterialTheme.colorScheme.primary]
+ * @param content composable lambda rendered centered inside the die asset
+ */
+@Composable
+fun DiceImage(
+    dice: Dice,
+    sizeVariant: DiceImageSize,
+    modifier: Modifier = Modifier,
+    tintColor: Color = MaterialTheme.colorScheme.primary,
+    content: @Composable () -> Unit = {},
+) {
+    Box(
+        modifier = modifier.size(sizeVariant.sizeDp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Image(
+            painter = painterResource(id = DiceAsset.fromDice(dice)),
+            contentDescription = contentDescriptionFor(dice),
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(ASSET_INNER_PADDING),
+            contentScale = ContentScale.Fit,
+            colorFilter = ColorFilter.tint(tintColor),
+        )
+        content()
+    }
+}
+
+/**
+ * Returns a localised content description for the given [dice] type.
+ *
+ * Kept as a private helper so the description string is derived from the
+ * same die name used throughout the domain layer.
+ */
+@Composable
+private fun contentDescriptionFor(dice: Dice): String =
+    stringResource(R.string.dice_image_content_description, dice.name)
+
+// -- Previews -----------------------------------------------------------------
+
+@Preview(name = "D4 Small", showBackground = true)
+@Composable
+private fun DiceImageD4SmallPreview() {
+    DiceRollerTheme(dynamicColor = false) {
+        DiceImage(dice = Dice.D4, sizeVariant = DiceImageSize.Small)
+    }
+}
+
+@Preview(name = "D6 Small — selected", showBackground = true)
+@Composable
+private fun DiceImageD6SmallSelectedPreview() {
+    DiceRollerTheme(dynamicColor = false) {
+        DiceImage(
+            dice = Dice.D6,
+            sizeVariant = DiceImageSize.Small,
+            tintColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        )
+    }
+}
+
+@Preview(name = "D8 Large", showBackground = true)
+@Composable
+private fun DiceImageD8LargePreview() {
+    DiceRollerTheme(dynamicColor = false) {
+        DiceImage(dice = Dice.D8, sizeVariant = DiceImageSize.Large)
+    }
+}
+
+@Preview(name = "D12 Large", showBackground = true)
+@Composable
+private fun DiceImageD12LargePreview() {
+    DiceRollerTheme(dynamicColor = false) {
+        DiceImage(dice = Dice.D12, sizeVariant = DiceImageSize.Large)
+    }
+}
+
+@Preview(name = "D20 Large", showBackground = true)
+@Composable
+private fun DiceImageD20LargePreview() {
+    DiceRollerTheme(dynamicColor = false) {
+        DiceImage(dice = Dice.D20, sizeVariant = DiceImageSize.Large)
+    }
+}

--- a/app/src/main/java/fr/mandarine/diceroller/presentation/model/DiceAsset.kt
+++ b/app/src/main/java/fr/mandarine/diceroller/presentation/model/DiceAsset.kt
@@ -1,0 +1,34 @@
+// app/src/main/java/fr/mandarine/diceroller/presentation/model/DiceAsset.kt
+package fr.mandarine.diceroller.presentation.model
+
+import androidx.annotation.DrawableRes
+import fr.mandarine.diceroller.R
+import fr.mandarine.diceroller.domain.Dice
+
+/**
+ * Maps each [Dice] enum value to its static drawable resource ID.
+ *
+ * This is the single source of truth for the Dice → drawable asset mapping.
+ * All paths must use tintable single-color Vector Drawables so that
+ * [DiceImage] can apply runtime tinting from the Material 3 color scheme.
+ *
+ * Adding a new die type requires updating [Dice] and adding a branch here —
+ * the compiler enforces exhaustiveness.
+ */
+object DiceAsset {
+
+    /**
+     * Returns the [DrawableRes] resource ID for the given [dice] type.
+     *
+     * The `when` expression is exhaustive — the compiler will flag any
+     * missing branch if a new [Dice] variant is added.
+     */
+    @DrawableRes
+    fun fromDice(dice: Dice): Int = when (dice) {
+        Dice.D4 -> R.drawable.ic_dice_d4
+        Dice.D6 -> R.drawable.ic_dice_d6
+        Dice.D8 -> R.drawable.ic_dice_d8
+        Dice.D12 -> R.drawable.ic_dice_d12
+        Dice.D20 -> R.drawable.ic_dice_d20
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,5 @@
 <resources>
     <string name="app_name">DiceRoller</string>
+    <!-- DiceImage content description. Parameter: die name e.g. "D6" -->
+    <string name="dice_image_content_description">%1$s die</string>
 </resources>


### PR DESCRIPTION
## Summary
- `DiceAsset` object added to `presentation/model/`: single-source-of-truth mapping from `Dice` enum to `@DrawableRes Int` via exhaustive `when` expression — compiler enforces exhaustiveness
- `DiceImage` composable added to `presentation/component/`: renders the static drawable via `painterResource(DiceAsset.fromDice(dice))` with `ColorFilter.tint` for automatic dark/light mode adaptation
- `DiceImageSize` enum (Small 48 dp, Large 160 dp) replaces `DicePolygonSize`
- Content slot in `DiceImage` allows callers (e.g. `DiceResultDisplay`) to overlay result numbers or `D6Pips` on top of the die art
- String resource `dice_image_content_description` added for accessibility
- Build verified: `./gradlew compileDebugKotlin` passes

## Closes
Closes #34

## Test plan
- [ ] Unit tests pass
- [ ] UI tests pass
- [ ] Manually verified on emulator