### PR TITLE
feat(domain): add dice pool model and pool-rolling

### DIFF
--- a/app/src/main/java/fr/mandarine/diceroller/domain/DiceGroupResult.kt
+++ b/app/src/main/java/fr/mandarine/diceroller/domain/DiceGroupResult.kt
@@ -1,0 +1,17 @@
+// app/src/main/java/fr/mandarine/diceroller/domain/DiceGroupResult.kt
+package fr.mandarine.diceroller.domain
+
+/**
+ * One die type's contribution to a [DicePoolResult]: how many dice of that [dice] type were
+ * rolled, and the resulting per-value tallies.
+ *
+ * @property dice the die type this group covers
+ * @property poolCount how many dice of [dice] were rolled, i.e. the pool count for this type
+ * @property tallies per-value tallies, sorted descending by [ValueTally.value], with values that
+ *   were rolled zero times omitted entirely
+ */
+data class DiceGroupResult(
+    val dice: Dice,
+    val poolCount: Int,
+    val tallies: List<ValueTally>,
+)

--- a/app/src/main/java/fr/mandarine/diceroller/domain/DicePool.kt
+++ b/app/src/main/java/fr/mandarine/diceroller/domain/DicePool.kt
@@ -1,0 +1,47 @@
+// app/src/main/java/fr/mandarine/diceroller/domain/DicePool.kt
+package fr.mandarine.diceroller.domain
+
+/**
+ * A validated, immutable mixed dice pool: how many dice of each [Dice] type are queued to be
+ * rolled together in one [DiceRoller.rollPool] call.
+ *
+ * Every count must be within [0, MAX_DICE_PER_TYPE]. Die types absent from [counts] are treated
+ * as a count of zero. [entries] exposes only the non-zero die types, already sorted
+ * smallest-to-largest by [Dice.faces] so callers never need to re-derive that ordering.
+ *
+ * @property counts the raw die-type-to-count map this pool was built from
+ * @throws IllegalArgumentException if any count is negative or exceeds [MAX_DICE_PER_TYPE]
+ */
+data class DicePool(private val counts: Map<Dice, Int> = emptyMap()) {
+
+    init {
+        counts.forEach { (dice, count) ->
+            require(count in 0..MAX_DICE_PER_TYPE) {
+                "Count for $dice must be within 0..$MAX_DICE_PER_TYPE, was $count"
+            }
+        }
+    }
+
+    /**
+     * Non-zero (die type, count) pairs, ordered smallest-to-largest by [Dice.faces].
+     */
+    val entries: List<Pair<Dice, Int>> =
+        counts.filterValues { it > 0 }.toList().sortedBy { (dice, _) -> dice.faces }
+
+    /**
+     * True when every die type in this pool has a count of zero.
+     */
+    val isEmpty: Boolean get() = entries.isEmpty()
+
+    /**
+     * Returns the count for [dice], or 0 if it is absent from this pool.
+     */
+    fun countFor(dice: Dice): Int = counts[dice] ?: 0
+
+    companion object {
+        /**
+         * The maximum number of dice allowed for a single die type within a pool.
+         */
+        const val MAX_DICE_PER_TYPE: Int = 20
+    }
+}

--- a/app/src/main/java/fr/mandarine/diceroller/domain/DicePoolResult.kt
+++ b/app/src/main/java/fr/mandarine/diceroller/domain/DicePoolResult.kt
@@ -1,0 +1,15 @@
+// app/src/main/java/fr/mandarine/diceroller/domain/DicePoolResult.kt
+package fr.mandarine.diceroller.domain
+
+/**
+ * The outcome of rolling a [DicePool]: one result group per non-zero die type plus the total
+ * sum across every die rolled.
+ *
+ * @property groups per-die-type results, ordered smallest-to-largest by [Dice.faces], matching
+ *   [DicePool.entries]'s ordering
+ * @property total the sum of every rolled value across every group
+ */
+data class DicePoolResult(
+    val groups: List<DiceGroupResult>,
+    val total: Int,
+)

--- a/app/src/main/java/fr/mandarine/diceroller/domain/DiceRoller.kt
+++ b/app/src/main/java/fr/mandarine/diceroller/domain/DiceRoller.kt
@@ -14,4 +14,28 @@ class DiceRoller(private val random: Random = Random.Default) {
      * Rolls the given [dice] and returns a value between 1 and [Dice.faces] inclusive.
      */
     fun roll(dice: Dice): Int = random.nextInt(from = 1, until = dice.faces + 1)
+
+    /**
+     * Rolls every die in [pool], one independent uniformly-random result per die, and returns
+     * the results grouped and tallied per die type.
+     *
+     * Die-type groups are ordered smallest-to-largest by [Dice.faces], matching
+     * [DicePool.entries]. Within each group, tallies are sorted descending by rolled value, and
+     * values that were never rolled are omitted. An empty [pool] is a no-op that returns an
+     * empty [DicePoolResult].
+     */
+    fun rollPool(pool: DicePool): DicePoolResult {
+        val groups = pool.entries.map { (dice, count) -> rollGroup(dice, count) }
+        val total = groups.sumOf { group -> group.tallies.sumOf { it.value * it.count } }
+        return DicePoolResult(groups = groups, total = total)
+    }
+
+    private fun rollGroup(dice: Dice, count: Int): DiceGroupResult {
+        val tallies = List(count) { roll(dice) }
+            .groupingBy { it }
+            .eachCount()
+            .map { (value, tallyCount) -> ValueTally(value = value, count = tallyCount) }
+            .sortedByDescending { it.value }
+        return DiceGroupResult(dice = dice, poolCount = count, tallies = tallies)
+    }
 }

--- a/app/src/main/java/fr/mandarine/diceroller/domain/ValueTally.kt
+++ b/app/src/main/java/fr/mandarine/diceroller/domain/ValueTally.kt
@@ -1,0 +1,10 @@
+// app/src/main/java/fr/mandarine/diceroller/domain/ValueTally.kt
+package fr.mandarine.diceroller.domain
+
+/**
+ * How many dice within a [DiceGroupResult] landed on a given rolled [value].
+ *
+ * @property value the rolled face value
+ * @property count how many dice of the group landed on [value]; always greater than zero
+ */
+data class ValueTally(val value: Int, val count: Int)

--- a/app/src/test/java/fr/mandarine/diceroller/domain/DicePoolTest.kt
+++ b/app/src/test/java/fr/mandarine/diceroller/domain/DicePoolTest.kt
@@ -1,0 +1,104 @@
+// app/src/test/java/fr/mandarine/diceroller/domain/DicePoolTest.kt
+package fr.mandarine.diceroller.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DicePoolTest {
+
+    // --- Construction defaults ---
+
+    @Test
+    fun givenNoArguments_whenConstructed_thenPoolIsEmpty() {
+        val pool = DicePool()
+
+        assertTrue(pool.isEmpty)
+        assertTrue(pool.entries.isEmpty())
+    }
+
+    // --- Validation ---
+
+    @Test
+    fun givenNegativeCount_whenConstructed_thenThrows() {
+        assertThrows(IllegalArgumentException::class.java) {
+            DicePool(mapOf(Dice.D6 to -1))
+        }
+    }
+
+    @Test
+    fun givenCountAboveMax_whenConstructed_thenThrows() {
+        assertThrows(IllegalArgumentException::class.java) {
+            DicePool(mapOf(Dice.D6 to DicePool.MAX_DICE_PER_TYPE + 1))
+        }
+    }
+
+    @Test
+    fun givenCountEqualToMax_whenConstructed_thenSucceeds() {
+        val pool = DicePool(mapOf(Dice.D6 to DicePool.MAX_DICE_PER_TYPE))
+
+        assertEquals(DicePool.MAX_DICE_PER_TYPE, pool.countFor(Dice.D6))
+    }
+
+    @Test
+    fun givenCountOfZero_whenConstructed_thenSucceeds() {
+        val pool = DicePool(mapOf(Dice.D6 to 0))
+
+        assertEquals(0, pool.countFor(Dice.D6))
+    }
+
+    // --- entries: zero-count exclusion ---
+
+    @Test
+    fun givenPoolWithZeroCountEntries_whenReadingEntries_thenZeroCountsAreExcluded() {
+        val pool = DicePool(mapOf(Dice.D6 to 4, Dice.D8 to 0, Dice.D4 to 0))
+
+        assertEquals(listOf(Dice.D6 to 4), pool.entries)
+    }
+
+    // --- entries: ordering ---
+
+    @Test
+    fun givenMixedPool_whenReadingEntries_thenOrderedSmallestToLargestByFaces() {
+        val pool = DicePool(mapOf(Dice.D20 to 2, Dice.D4 to 3, Dice.D8 to 1, Dice.D6 to 1))
+
+        assertEquals(
+            listOf(Dice.D4 to 3, Dice.D6 to 1, Dice.D8 to 1, Dice.D20 to 2),
+            pool.entries,
+        )
+    }
+
+    // --- isEmpty ---
+
+    @Test
+    fun givenPoolWithOnlyZeroCounts_whenReadingIsEmpty_thenTrue() {
+        val pool = DicePool(mapOf(Dice.D6 to 0, Dice.D8 to 0))
+
+        assertTrue(pool.isEmpty)
+    }
+
+    @Test
+    fun givenPoolWithAtLeastOnePositiveCount_whenReadingIsEmpty_thenFalse() {
+        val pool = DicePool(mapOf(Dice.D6 to 1))
+
+        assertFalse(pool.isEmpty)
+    }
+
+    // --- countFor ---
+
+    @Test
+    fun givenDiceAbsentFromMap_whenReadingCountFor_thenZero() {
+        val pool = DicePool(mapOf(Dice.D6 to 5))
+
+        assertEquals(0, pool.countFor(Dice.D4))
+    }
+
+    @Test
+    fun givenDicePresentInMap_whenReadingCountFor_thenActualCount() {
+        val pool = DicePool(mapOf(Dice.D6 to 5))
+
+        assertEquals(5, pool.countFor(Dice.D6))
+    }
+}

--- a/app/src/test/java/fr/mandarine/diceroller/domain/DiceRollerTest.kt
+++ b/app/src/test/java/fr/mandarine/diceroller/domain/DiceRollerTest.kt
@@ -170,4 +170,125 @@ class DiceRollerTest {
             }
         }
     }
+
+    // --- rollPool: empty pool ---
+
+    @Test
+    fun givenEmptyPool_whenRollingPool_thenResultHasNoGroupsAndZeroTotal() {
+        val result = DiceRoller().rollPool(DicePool())
+
+        assertTrue(result.groups.isEmpty())
+        assertEquals(0, result.total)
+    }
+
+    // --- rollPool: group shape ---
+
+    @Test
+    fun givenSingleDieTypePool_whenRollingPool_thenOneGroupWithMatchingPoolCount() {
+        val pool = DicePool(mapOf(Dice.D6 to 5))
+
+        val result = DiceRoller(random = Random(seed = 1)).rollPool(pool)
+
+        assertEquals(1, result.groups.size)
+        assertEquals(Dice.D6, result.groups[0].dice)
+        assertEquals(5, result.groups[0].poolCount)
+    }
+
+    @Test
+    fun givenMixedPool_whenRollingPool_thenGroupsOrderedSmallestToLargest() {
+        val pool = DicePool(mapOf(Dice.D20 to 2, Dice.D4 to 3, Dice.D8 to 1))
+
+        val result = DiceRoller().rollPool(pool)
+
+        assertEquals(listOf(Dice.D4, Dice.D8, Dice.D20), result.groups.map { it.dice })
+    }
+
+    // --- rollPool: tally correctness ---
+
+    @Test
+    fun givenPool_whenRollingPool_thenTalliesSumToPoolCountPerGroup() {
+        val pool = DicePool(mapOf(Dice.D6 to 10, Dice.D8 to 6))
+
+        val result = DiceRoller().rollPool(pool)
+
+        result.groups.forEach { group ->
+            assertEquals(group.poolCount, group.tallies.sumOf { it.count })
+        }
+    }
+
+    @Test
+    fun givenPool_whenRollingPool_thenEveryTalliedValueIsWithinDiceFaceRange() {
+        val pool = DicePool(mapOf(Dice.D4 to 20, Dice.D20 to 20))
+
+        val result = DiceRoller().rollPool(pool)
+
+        result.groups.forEach { group ->
+            group.tallies.forEach { tally ->
+                assertTrue(
+                    "Expected value in 1..${group.dice.faces}, got ${tally.value}",
+                    tally.value in 1..group.dice.faces,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun givenPool_whenRollingPool_thenTalliesWithinGroupAreSortedDescendingByValue() {
+        val pool = DicePool(mapOf(Dice.D6 to 20))
+
+        val result = DiceRoller().rollPool(pool)
+
+        val values = result.groups.first().tallies.map { it.value }
+        assertEquals(values.sortedDescending(), values)
+    }
+
+    @Test
+    fun givenPool_whenRollingPool_thenNoZeroCountTalliesAppear() {
+        val pool = DicePool(mapOf(Dice.D6 to 20))
+
+        val result = DiceRoller().rollPool(pool)
+
+        result.groups.forEach { group ->
+            group.tallies.forEach { tally -> assertTrue(tally.count > 0) }
+        }
+    }
+
+    // --- rollPool: total ---
+
+    @Test
+    fun givenPool_whenRollingPool_thenTotalEqualsSumOfAllRolledValues() {
+        val pool = DicePool(mapOf(Dice.D6 to 4, Dice.D8 to 2))
+
+        val result = DiceRoller().rollPool(pool)
+
+        val expectedTotal = result.groups.sumOf { group ->
+            group.tallies.sumOf { it.value * it.count }
+        }
+        assertEquals(expectedTotal, result.total)
+    }
+
+    // --- rollPool: existing single-die roll is unaffected ---
+
+    @Test
+    fun givenSameSeed_whenRollingPoolOfOne_thenMatchesDirectRollCall() {
+        val poolRoller = DiceRoller(random = Random(seed = 7))
+        val directRoller = DiceRoller(random = Random(seed = 7))
+
+        val poolResult = poolRoller.rollPool(DicePool(mapOf(Dice.D6 to 1)))
+        val directResult = directRoller.roll(Dice.D6)
+
+        assertEquals(directResult, poolResult.groups.first().tallies.first().value)
+    }
+
+    // --- rollPool: determinism ---
+
+    @Test
+    fun givenSameSeed_whenRollingPoolTwice_thenResultsAreEqual() {
+        val pool = DicePool(mapOf(Dice.D6 to 4, Dice.D8 to 2))
+
+        val first = DiceRoller(random = Random(seed = 55)).rollPool(pool)
+        val second = DiceRoller(random = Random(seed = 55)).rollPool(pool)
+
+        assertEquals(first, second)
+    }
 }

--- a/app/src/test/java/fr/mandarine/diceroller/domain/DiceRollerTest.kt
+++ b/app/src/test/java/fr/mandarine/diceroller/domain/DiceRollerTest.kt
@@ -181,6 +181,16 @@ class DiceRollerTest {
         assertEquals(0, result.total)
     }
 
+    @Test
+    fun givenPoolWhereEveryCountIsZero_whenRollingPool_thenResultHasNoGroupsAndZeroTotal() {
+        val pool = DicePool(mapOf(Dice.D6 to 0, Dice.D8 to 0, Dice.D20 to 0))
+
+        val result = DiceRoller().rollPool(pool)
+
+        assertTrue(result.groups.isEmpty())
+        assertEquals(0, result.total)
+    }
+
     // --- rollPool: group shape ---
 
     @Test
@@ -192,6 +202,16 @@ class DiceRollerTest {
         assertEquals(1, result.groups.size)
         assertEquals(Dice.D6, result.groups[0].dice)
         assertEquals(5, result.groups[0].poolCount)
+    }
+
+    @Test
+    fun givenSingleDiePoolOfCountOne_whenRollingPool_thenGroupHasExactlyOneTallyOfCountOne() {
+        val pool = DicePool(mapOf(Dice.D8 to 1))
+
+        val result = DiceRoller(random = Random(seed = 3)).rollPool(pool)
+
+        val group = result.groups.single()
+        assertEquals(1, group.tallies.single().count)
     }
 
     @Test
@@ -251,6 +271,53 @@ class DiceRollerTest {
         result.groups.forEach { group ->
             group.tallies.forEach { tally -> assertTrue(tally.count > 0) }
         }
+    }
+
+    @Test
+    fun givenSeededMixedPool_whenRollingPool_thenEachGroupRollsExactlyItsPoolCountIndependently() {
+        val pool = DicePool(mapOf(Dice.D6 to 4, Dice.D8 to 2))
+
+        val result = DiceRoller(random = Random(seed = 2024)).rollPool(pool)
+
+        assertEquals(listOf(4, 2), result.groups.map { it.poolCount })
+        assertEquals(listOf(4, 2), result.groups.map { group -> group.tallies.sumOf { it.count } })
+    }
+
+    @Test
+    fun givenSeededMixedPool_whenRollingPool_thenTalliesMatchIndependentlyReplayedRolls() {
+        val seed = 2024L
+        val pool = DicePool(mapOf(Dice.D6 to 4, Dice.D8 to 2))
+
+        val result = DiceRoller(random = Random(seed)).rollPool(pool)
+
+        // Replay the same die-by-die, group-by-group sequence with a fresh roller seeded
+        // identically, to independently derive what the per-value tallies should be.
+        val replayRoller = DiceRoller(random = Random(seed))
+        val expectedTalliesPerGroup = pool.entries.map { (dice, count) ->
+            List(count) { replayRoller.roll(dice) }.groupingBy { it }.eachCount()
+        }
+
+        result.groups.forEachIndexed { index, group ->
+            val actualTallyMap = group.tallies.associate { it.value to it.count }
+            assertEquals(expectedTalliesPerGroup[index], actualTallyMap)
+        }
+    }
+
+    @Test
+    fun givenPool_whenRollingPool_thenValuesNeverRolledAreAbsentFromTallies() {
+        // A D6 pool of size 3 has at most 3 distinct rolled values out of 6 possible faces,
+        // so at least some face values are guaranteed to be absent from the tally.
+        val pool = DicePool(mapOf(Dice.D6 to 3))
+
+        val result = DiceRoller(random = Random(seed = 11)).rollPool(pool)
+
+        val talliedValues = result.groups.single().tallies.map { it.value }.toSet()
+        val possibleValues = (1..Dice.D6.faces).toSet()
+        assertTrue(
+            "Expected at least one untallied value, tallied=$talliedValues",
+            talliedValues.size < possibleValues.size,
+        )
+        assertTrue(possibleValues.containsAll(talliedValues))
     }
 
     // --- rollPool: total ---


### PR DESCRIPTION
## Summary
- Adds `DicePool` — a validated die-type→count map (0-20 per type, non-zero entries exposed smallest-to-largest by `Dice.faces`)
- Adds the result shapes `DicePoolResult` (groups + total), `DiceGroupResult` (die type, pool count, tallies), and `ValueTally` (value, count)
- Adds `DiceRoller.rollPool(pool): DicePoolResult`, which rolls every die in the pool via the existing seeded `roll(dice)`, groups by die type, and tallies values per group (descending by value, zero-count values omitted); an empty pool is a no-op returning an empty result
- No changes to the existing `roll(dice)` behavior; no Android imports in the domain layer

## Closes
Closes #48

## Test plan
- [x] Unit tests pass (`DicePoolTest`, extended `DiceRollerTest`) — validation bounds, zero-count exclusion, group/tally ordering, total sum, determinism, and parity with the existing single-die `roll(dice)`
- [ ] UI tests pass (not applicable — domain layer only, no UI changes in this issue)
- [ ] Manually verified on emulator (not applicable — no UI wiring in this issue; consumed by issue #47)